### PR TITLE
Fix 'NamedString' object error in 'upload_and_process' function

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ def gradio_interface():
     def upload_and_process(file):
         filepath = os.path.join(app.config['UPLOAD_FOLDER'], file.name)
         with open(filepath, 'wb') as f:
-            f.write(file.read())
+            f.write(file.file.read())
         segments = analyze_video(filepath)
         clips = create_clips(filepath, segments)
         processed_clips = []
@@ -115,7 +115,7 @@ def gradio_interface():
     def upload_and_train(file):
         filepath = os.path.join(app.config['TRAINING_FOLDER'], file.name)
         with open(filepath, 'wb') as f:
-            f.write(file.read())
+            f.write(file.file.read())
         # Placeholder for model training logic
         return "File uploaded and model training started"
 


### PR DESCRIPTION
Fix the 'NamedString' object error in the 'upload_and_process' function in `main.py`.

* Update the `upload_and_process` function to use `file.file.read()` instead of `file.read()`.
* Update the `upload_and_train` function to use `file.file.read()` instead of `file.read()`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jmontgomery30/moneyclip?shareId=6662563f-04fb-4784-9e4b-c1892fdaa2ef).